### PR TITLE
fix: remove component name from release-please tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "include-component-in-tag": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Add `include-component-in-tag: false` to release-please config so tags are `v2.1.0` instead of `kanagawa-paper-v2.1.0`

## Test plan
- [ ] Verify next release-please PR creates a tag without the component name